### PR TITLE
updated total expense to integer

### DIFF
--- a/app.js
+++ b/app.js
@@ -58,8 +58,8 @@ function updateExpensesList() {
 }
 
 function updateTotalExpenses() {
-    const total = expenses.reduce((acc, expense) => acc + expense.amount, 0);
-    totalExpenses.textContent = `$${total.toFixed(2)}`;
+    const total = expenses.reduce((acc, expense) => acc + Math.round(expense.amount), 0);
+    totalExpenses.textContent = `$${total}`;
 }
 
 function createSnowflake() {

--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
 
         <div id="expenses-card">
             <h2>Total Expenses 💰 </h2>
-            <div id="total-expenses"> $0.00 </div>
+            <div id="total-expenses"> $0 </div>
         </div>
 
         <div id="expenses-list">


### PR DESCRIPTION
Fixes #6 

I updated the total expense to a whole number.

I used the `Math.round()` function to round the number properly.

![image](https://github.com/SnehaDeshmukh28/Basic-Personal-Finance-Tracker/assets/66525499/ce8e38ad-7f86-472d-8620-a4403e10abf7)

So basically it adds the properly rounded integer to the current account balance.

Works just fine as you can see here:

![image](https://github.com/SnehaDeshmukh28/Basic-Personal-Finance-Tracker/assets/66525499/3f9a0625-d627-421f-aa23-83cfd9a2e96e)

- [x] 12.44 gets rounded to 12 since the decimal is less than 50 
- [X] 12.55 gets rounded to 13 since the decimal is greater than 50
- [X] So it's a total of 12+13 = 25